### PR TITLE
Add support for package names

### DIFF
--- a/content/home.php
+++ b/content/home.php
@@ -150,7 +150,7 @@
 					}elseif($product['type'] == 'stream'){
 						$type = $lang->translate(679);
 					}
-					$html .= '<tr><td><a href="?lang='.lang_get_value_defaultlang().'&page='.$product['type'].'&id='.$product['pakket_id'].'"><u>'.$type.' '.$product['pakket_id'].'</u></a></td><td>';
+					$html .= '<tr><td><a href="?lang='.lang_get_value_defaultlang().'&page='.$product['type'].'&id='.$product['pakket_id'].'"><u>'.$type.' - '.$product['pakket_name'].'</u></a></td><td>';
 					if(check_user_right(get_value_session('from_db','id'),'klantbekijken',get_value_session('from_db','is_admin')) != FALSE){
 					$html .= '<u><a href="?lang='.lang_get_value_defaultlang().'&page=klanten&type=bekijken&id='.$userdata['id'].'">'.$userdata['username'].'</a></u>';
 					}else{

--- a/content/producten.php
+++ b/content/producten.php
@@ -61,7 +61,7 @@
 						$html .= '<div class="tablestop1"><table>';
 							
 							$html .= '<tr><td>'.$lang->translate(1200).'</td><td>'.$lang->translate(664).'</td><td>'.$lang->translate(665).'</td></tr>';
-							$html .= '<tr><td>'.$lang->translate(690).'</td><td>'.$pakket_name.'</td><td><input type="text" name="pakket_name" id="domlimit" value="'.$pakket_name.'"></td></tr>';
+							$html .= '<tr><td>'.$lang->translate(690).'</td><td> - </td><td><input type="text" name="pakket_name" id="domlimit" value="'.$pakket_name.'"></td></tr>';
 							$html .= '<tr><td>'.$lang->translate(666).'</td><td>'.$domain_pakket_used.'</td><td><input type="text" name="domlimit" id="domlimit" value="'.$domain_pakket_limit.'"></td></tr>';
 							$html .= '<tr><td>'.$lang->translate(667).'</td><td>'.$template_pakket_used.'</td><td><input type="text" name="temlimit" id="temlimit" value="'.$template_pakket_limit.'"></td></tr>';
 							$html .= '<tr><td>'.$lang->translate(668).'</td><td>'.$domain_total_used.'</td><td>'.$domain_total_limit.'</td></tr>';
@@ -95,7 +95,7 @@
 						$html .= ''.$lang->translate(671).'<br /><br /></p>';
 						$html .= '<div class="tablestop1"><table>';
 						$html .= '<tr><td>'.$lang->translate(1200).'</td><td>'.$lang->translate(664).'</td><td>'.$lang->translate(665).'</td></tr>';
-						$html .= '<tr><td>'.$lang->translate(690).'</td><td>'.$pakket_name.'</td><td>'.$pakket_name.'</td></tr>';
+						$html .= '<tr><td>'.$lang->translate(690).'</td><td> - </td><td>'.$pakket_name.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(666).'</td><td>'.$domain_pakket_used.'</td><td>'.$domain_pakket_limit.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(667).'</td><td>'.$template_pakket_used.'</td><td>'.$template_pakket_limit.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(668).'</td><td>'.$domain_total_used.'</td><td>'.$domain_total_limit.'</td></tr>';
@@ -115,7 +115,7 @@
 						$html .= ''.$lang->translate(682).'<br /><br />';
 						$html .= '<table border="1">';
 						$html .= '<tr><td></td><td>'.$lang->translate(664).'</td><td>'.$lang->translate(665).'</td></tr>';
-						$html .= '<tr><td>'.$lang->translate(690).'</td><td>'.$pakket_name.'</td><td>'.$pakket_name.'</td></tr>';
+						$html .= '<tr><td>'.$lang->translate(690).'</td><td> - </td><td>'.$pakket_name.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(680).'</td><td>'.$listeners_pakket_used.'</td><td>'.$listeners_pakket_limit.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(681).'</td><td>'.$listeners_total_used.'</td><td>'.$listeners_total_limit.'</td></tr>';
 						$html .= '</table>';

--- a/content/producten.php
+++ b/content/producten.php
@@ -44,6 +44,7 @@
 								$html .= '<br /><p><b>'.$lang->translate(674).'</b></p><br /><br />';
 							}
 						}else{
+							$pakket_name	=	$pakket['pakket_name'];
 							$domain_pakket_limit = dns_get_value_pakket($pakket['pakket_id'],'domain');
 							$template_pakket_limit = dns_get_value_pakket($pakket['pakket_id'],'template');
 							$domain_pakket_used = dns_get_value_current_usage($pakket['pakket_id'],'domain');
@@ -60,6 +61,7 @@
 						$html .= '<div class="tablestop1"><table>';
 							
 							$html .= '<tr><td>'.$lang->translate(1200).'</td><td>'.$lang->translate(664).'</td><td>'.$lang->translate(665).'</td></tr>';
+							$html .= '<tr><td>'.$lang->translate(690).'</td><td>'.$pakket_name.'</td><td><input type="text" name="pakket_name" id="domlimit" value="'.$pakket_name.'"></td></tr>';
 							$html .= '<tr><td>'.$lang->translate(666).'</td><td>'.$domain_pakket_used.'</td><td><input type="text" name="domlimit" id="domlimit" value="'.$domain_pakket_limit.'"></td></tr>';
 							$html .= '<tr><td>'.$lang->translate(667).'</td><td>'.$template_pakket_used.'</td><td><input type="text" name="temlimit" id="temlimit" value="'.$template_pakket_limit.'"></td></tr>';
 							$html .= '<tr><td>'.$lang->translate(668).'</td><td>'.$domain_total_used.'</td><td>'.$domain_total_limit.'</td></tr>';
@@ -78,6 +80,7 @@
 			if($pakket !== FALSE){
 				if(get_value_get('p') == "dns"){
 					if(check_user_subuser(get_value_session('from_db','id'),$pakket['user_id'],$type = 3) !== FALSE || $pakket['user_id'] == get_value_session('from_db','id') || get_value_session('from_db','is_admin') == '1'){
+						$pakket_name	=	$pakket['pakket_name'];
 						$domain_pakket_limit = dns_get_value_pakket($pakket['pakket_id'],'domain');
 						$template_pakket_limit = dns_get_value_pakket($pakket['pakket_id'],'template');
 						$domain_pakket_used = dns_get_value_current_usage($pakket['pakket_id'],'domain');
@@ -92,6 +95,7 @@
 						$html .= ''.$lang->translate(671).'<br /><br /></p>';
 						$html .= '<div class="tablestop1"><table>';
 						$html .= '<tr><td>'.$lang->translate(1200).'</td><td>'.$lang->translate(664).'</td><td>'.$lang->translate(665).'</td></tr>';
+						$html .= '<tr><td>'.$lang->translate(690).'</td><td>'.$pakket_name.'</td><td>'.$pakket_name.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(666).'</td><td>'.$domain_pakket_used.'</td><td>'.$domain_pakket_limit.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(667).'</td><td>'.$template_pakket_used.'</td><td>'.$template_pakket_limit.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(668).'</td><td>'.$domain_total_used.'</td><td>'.$domain_total_limit.'</td></tr>';
@@ -100,6 +104,7 @@
 					}
 				}elseif(get_value_get('p') == "stream"){
 					if(check_user_subuser(get_value_session('from_db','id'),$pakket['user_id'],$type = 3) !== FALSE || $pakket['user_id'] == get_value_session('from_db','id') || get_value_session('from_db','is_admin') == '1'){
+						$pakket_name	=	$pakket['pakket_name'];
 						$listeners_pakket_limit = stream_get_value_pakket($pakket['pakket_id'],'listeners');
 						$listeners_pakket_used = stream_get_value_current_usage($pakket['pakket_id'],'listeners');
 						$listeners_total_limit = pakketten_get_value_size_stream($pakket['user_id'],'listeners');
@@ -110,6 +115,7 @@
 						$html .= ''.$lang->translate(682).'<br /><br />';
 						$html .= '<table border="1">';
 						$html .= '<tr><td></td><td>'.$lang->translate(664).'</td><td>'.$lang->translate(665).'</td></tr>';
+						$html .= '<tr><td>'.$lang->translate(690).'</td><td>'.$pakket_name.'</td><td>'.$pakket_name.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(680).'</td><td>'.$listeners_pakket_used.'</td><td>'.$listeners_pakket_limit.'</td></tr>';
 						$html .= '<tr><td>'.$lang->translate(681).'</td><td>'.$listeners_total_used.'</td><td>'.$listeners_total_limit.'</td></tr>';
 						$html .= '</table>';

--- a/content/producten.php
+++ b/content/producten.php
@@ -476,7 +476,7 @@
 					}elseif($product['type'] == 'stream'){
 						$type = $lang->translate(679);
 					}
-					$html .= '<tr><td><a href="?lang='.lang_get_value_defaultlang().'&page='.$product['type'].'&id='.$product['pakket_id'].'"><u>'.$type.' '.$product['pakket_id'].'</u></a></td><td>';
+					$html .= '<tr><td><a href="?lang='.lang_get_value_defaultlang().'&page='.$product['type'].'&id='.$product['pakket_id'].'"><u>'.$type.' - '.$product['pakket_name'].'</u></a></td><td>';
 					if(check_user_right(get_value_session('from_db','id'),'klantbekijken',get_value_session('from_db','is_admin')) != FALSE){
 					$html .= '<u><a href="?lang='.lang_get_value_defaultlang().'&page=klanten&type=bekijken&id='.$userdata['id'].'">'.$userdata['username'].'</a></u>';
 					}else{

--- a/dnsshop.sql
+++ b/dnsshop.sql
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS `pakketten` (
   `type` varchar(25) NOT NULL,
   `user_id` int(255) NOT NULL,
   `pakket_id` int(255) NOT NULL,
+  `pakket_name` varchar(25) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `type` (`type`,`user_id`,`pakket_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1 ;

--- a/function.php
+++ b/function.php
@@ -564,10 +564,10 @@
 			foreach($pakketten as $pakket){
 				if($pakket['user_id'] == get_value_session('from_db','id')){
 					if($pakket['type'] == 'dns'){
-						$menu[$lang->translate(25)][$lang->translate(26).' '.$pakket['pakket_id']]['url'] = '&page='.$pakket['type'].'&id='.$pakket['pakket_id'];
+						$menu[$lang->translate(25)][$pakket['pakket_name']]['url'] = '&page='.$pakket['type'].'&id='.$pakket['pakket_id'];
 						$menu[$lang->translate(25)][$lang->translate(26).' '.$pakket['pakket_id']]['plaatje'] = 'dns.png';
 					}elseif($pakket['type'] == 'stream'){
-						$menu[$lang->translate(25)][$lang->translate(27).' '.$pakket['pakket_id']]['url'] = '&page='.$pakket['type'].'&id='.$pakket['pakket_id'];
+						$menu[$lang->translate(25)][$pakket['pakket_name']]['url'] = '&page='.$pakket['type'].'&id='.$pakket['pakket_id'];
 						$menu[$lang->translate(25)][$lang->translate(27).' '.$pakket['pakket_id']]['plaatje'] = 'stream.png';
 					}
 				}

--- a/lang/en.csv
+++ b/lang/en.csv
@@ -270,6 +270,7 @@
 680,Listeners within the package;
 681,Total Listeners within from user;
 682,Type package: Streaming;
+690,Package name;
 701,It was impossible to find something to display;
 702,Domain name;
 703,Template name;

--- a/lang/nl.csv
+++ b/lang/nl.csv
@@ -277,6 +277,7 @@
 680,Luisteraars binnen het pakket;
 681,Totaal luisteraars van gebruiker;
 682,Type pakket: Streaming;
+690,Pakketnaam;
 701,Er kon niets gevonden worden om weer te geven;
 702,Domeinnaam;
 703,Template naam;

--- a/packagename.sql
+++ b/packagename.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pakketten` ADD `pakket_naam` VARCHAR( 25 ) NOT NULL;


### PR DESCRIPTION
This is a pull request for issue #12 . With this pull request it should be possible to enter, edit and show package names instead of the package ID's.

SQL fix to add support for people who are already using dnsshop.

Changes not tested.